### PR TITLE
Ignoring some linter errors to fix imports

### DIFF
--- a/api/v0/__init__.py
+++ b/api/v0/__init__.py
@@ -1,5 +1,5 @@
 from flask import Blueprint
 
-import api.v0.routes  # pylint: disable=cyclic-import
-
 api_v0 = Blueprint('mod_api_v0', __name__)
+
+import api.v0.routes  # pylint: disable=cyclic-import,wrong-import-position  # noqa: E402


### PR DESCRIPTION
Fix for this issue:
```
➜  backend (master) ✔ pipenv run start
Traceback (most recent call last):
  File "app.py", line 1, in <module>
    from api import app
  File "/Users/robertkim/dev/personal/number-eleven/backend/api/__init__.py", line 4, in <module>
    from api.v0 import api_v0
  File "/Users/robertkim/dev/personal/number-eleven/backend/api/v0/__init__.py", line 3, in <module>
    import api.v0.routes  # pylint: disable=cyclic-import
  File "/Users/robertkim/dev/personal/number-eleven/backend/api/v0/routes.py", line 3, in <module>
    from api.v0 import api_v0
ImportError: cannot import name 'api_v0' from 'api.v0' (/Users/robertkim/dev/personal/number-eleven/backend/api/v0/__init__.py)
```

`api_v0` can't be imported in `routes.py` because it's being imported in `api.v0` module before `api_v0` is initialized.